### PR TITLE
Remove quotes from Docker Compose YAML

### DIFF
--- a/docker/docker-compose-with-deps.yml
+++ b/docker/docker-compose-with-deps.yml
@@ -17,14 +17,14 @@ services:
       - DOMAIN_NAME=localhost
       - ALLOWED_HOSTS=*
       - TEMBA_HOST=localhost
-      - DJANGO_DEBUG="off"
+      - DJANGO_DEBUG=off
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY={$RAPIDPRO_SECRET_KEY:-super-secret-key}
-      - MANAGEPY_COLLECTSTATIC="on"
-      - MANAGEPY_COMPRESS="on"
-      - MANAGEPY_INIT_DB="on"
-      - MANAGEPY_MIGRATE="on"
+      - MANAGEPY_COLLECTSTATIC=off
+      - MANAGEPY_COMPRESS=off
+      - MANAGEPY_INIT_DB=off
+      - MANAGEPY_MIGRATE=off
     depends_on:
       - redis
       - postgresql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,14 +9,14 @@ services:
       - DOMAIN_NAME=localhost
       - ALLOWED_HOSTS=*
       - TEMBA_HOST=localhost
-      - DJANGO_DEBUG="off"
+      - DJANGO_DEBUG=off
       - DATABASE_URL={$RAPIDPRO_DB_URL:-postgresql://postgres:@10.200.10.1/rapidpro}
       - REDIS_URL=${RAPIDPRO_REDIS_URL:-redis://10.200.10.1:6379/0}
       - SECRET_KEY={$RAPIDPRO_SECRET_KEY:-super-secret-key}
-      - MANAGEPY_COLLECTSTATIC="on"
-      - MANAGEPY_COMPRESS="on"
-      - MANAGEPY_INIT_DB="on"
-      - MANAGEPY_MIGRATE="on"
+      - MANAGEPY_COLLECTSTATIC=off
+      - MANAGEPY_COMPRESS=off
+      - MANAGEPY_INIT_DB=off
+      - MANAGEPY_MIGRATE=off
 
   celery:
     image: ${RAPIDPRO_IMAGE:-praekeltfoundation/rapidpro:latest}


### PR DESCRIPTION
It looks like the quotes are included in the final value of the environment variable which gives lines like this in stdout:

```
rapidpro_1     | + [ x"on" = xon ]
```

This commit removes the quotes from the YAML and changes the `"on"` to `off` because that has the same meaning.